### PR TITLE
fix: improve search scoring for numeric queries

### DIFF
--- a/static/files.js
+++ b/static/files.js
@@ -190,6 +190,11 @@ function resetSearchFilter() {
 
 function __scoreByName(el, query) {
   let total = __score(el.dataset.name, query);
+  // For pure numeric queries (e.g. "26"), also try episode notation (e.g. "e26")
+  // so that "S01E26" style filenames match consistently with "- 26 " style
+  if (/^\d+$/.test(query)) {
+    total = Math.max(total, __score(el.dataset.name, `e${query}`));
+  }
   let native = el.dataset.japaneseName;
   if (native !== null) {
     total = Math.max(total, __score(native, query));


### PR DESCRIPTION
This PR improves the search scoring logic for pure numeric queries, such as episode numbers.

When a query is purely numeric (e.g., `26`), we now also attempt to match it against the filename with an `e` prefix (e.g., `e26`). This ensures that files using the `S01E26` format rank appropriately alongside files using simpler `- 26` notation.

Fixes #30