### PR TITLE
chore: ignore VS Code workspace settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /subtitles
 /logs
+
+.vscode


### PR DESCRIPTION
While inspecting the codebase, I ran into an issue with my editor’s global format-on-save settings. Saving JavaScript files reformatted them according to my local editor configuration, which made the Git diff much harder to review.

The project has formatting configuration for Rust, but does not appear to define formatting rules for JavaScript files. Ignoring `.vscode` lets contributors keep project-specific editor settings, such as disabling JS format-on-save without affecting other projects or accidentally committing local workspace preferences.

I understand this may be considered a local preference that belongs in `.git/info/exclude` instead, so feel free to close this if you prefer not to track editor-specific ignore rules in the repository.