### PR TITLE
chore: default subtitle path to subtitles directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -62,7 +62,9 @@ impl Config {
         Ok(Self {
             production: false,
             lets_encrypt_production: false,
-            subtitle_path: std::env::current_dir().expect("could not get current working directory"),
+            subtitle_path: std::env::current_dir()
+                .expect("could not get current working directory")
+                .join("subtitles"),
             domains: Vec::new(),
             contact_emails: Vec::new(),
             tmdb_api_key: String::new(),
@@ -90,6 +92,10 @@ impl Config {
             let parent = path.parent().unwrap();
             if !parent.exists() {
                 std::fs::create_dir(parent).context("could not create config directory")?;
+            }
+
+            if !config.subtitle_path.exists() {
+                std::fs::create_dir(&config.subtitle_path).context("could not create subtitle directory")?;
             }
 
             let file = std::fs::File::create(path).context("could not create config file")?;


### PR DESCRIPTION
The repository already ignores `/subtitles`, which suggests local subtitle files are expected to live there. However, newly generated configs currently default `subtitle_path` to the current working directory, so creating entries during local development can place subtitle folders directly in the repository root.

This changes newly generated configs to use `./subtitles` by default and creates that directory during initial config generation.

This should make the initial setup easier for contributors, since they no longer need to manually change `subtitle_path` in the config or run `cargo run -- move` after creating directory entries with the default configuration.