### PR TITLE
fix: improve numeric episode search

### DIFF
--- a/static/files.js
+++ b/static/files.js
@@ -3,6 +3,8 @@ const filterElement = document.getElementById('search-files');
 const escapedRegex = /[-\/\\^$*+?.()|[\]{}]/g;
 const escapeRegex = (e) => e.replace(escapedRegex, '\\$&');
 const MIN_SCORE = -1500;
+const releaseMetadataRegex = /\[(?=[^\]]*[^\d\]])[^\]]*\]|\([^)]*\)/g;
+const seasonPrefixRegex = /\b(?:Season|S)\s*\d{1,2}\s*-\s*/gi;
 
 function __score(haystack, query) {
   let result = fuzzysort.single(__normalizeString(query), __normalizeString(haystack));
@@ -11,6 +13,14 @@ function __score(haystack, query) {
 
 function __normalizeString(s) {
   return s ? s.normalize('NFKD').replace(/[\u0300-\u036f]/g, "") : s;
+}
+
+function __matchesEpisodeNumber(name, query) {
+  name = name
+    .replace(releaseMetadataRegex, '')
+    .replace(seasonPrefixRegex, '');
+  const episodeNumber = new RegExp(`(?:[sS]\\d{1,2}[eE]|(?:^|[^A-Za-z0-9]))0*${parseInt(query, 10)}(?!\\d)`);
+  return episodeNumber.test(name);
 }
 
 const changeModifiedToRelative = () => {
@@ -190,10 +200,8 @@ function resetSearchFilter() {
 
 function __scoreByName(el, query) {
   let total = __score(el.dataset.name, query);
-  // For pure numeric queries (e.g. "26"), also try episode notation (e.g. "e26")
-  // so that "S01E26" style filenames match consistently with "- 26 " style
-  if (/^\d+$/.test(query)) {
-    total = Math.max(total, __score(el.dataset.name, `e${query}`));
+  if (/^\d+$/.test(query) && __matchesEpisodeNumber(el.dataset.name, query)) {
+    return 0;
   }
   let native = el.dataset.japaneseName;
   if (native !== null) {


### PR DESCRIPTION
## Summary

  This improves numeric file search so episode queries like `5`, `05`, `7`, and `07` can match episode numbers more reliably.

  ## Context

  While testing a few entries, I noticed that short numeric searches can return false negatives because they depend on fuzzy scoring. If the filename is long enough, the
  episode number may not score high enough to stay visible, even though a user searching for `07` is very likely trying to find episode 7.

  This is more noticeable in player-like integrations, where it is less convenient to manually scan a long file list.

  Examples where this can be reproduced:

  - https://jimaku.cc/entry/3813
  - https://jimaku.cc/entry/11339
  - https://jimaku.cc/entry/11856

  ## Change

  For numeric queries, this adds a direct episode-number check before falling back to fuzzy scoring.

  The check strips release metadata such as `[WebRip]`, `[CHS, JPN]`, and `(AT-X 1080p HEVC AAC)`, but keeps numeric bracketed episode markers such as `[08]`. It also handles both padded and non-padded queries while avoiding season-number matches like `S2` or `Season 2`. 

I removed the previous `e${query}` fallback because this direct episode-number check should cover the same `SxxExx` cases described in https://github.com/Rapptz/jimaku/issues/30.


## Manual test script

  There does not seem to be an existing frontend test setup for `static/files.js`, so I checked the matching behavior with Node's built-in test runner.

  ```js
  const test = require('node:test');
  const assert = require('node:assert/strict');

  const releaseMetadataRegex = /\[(?=[^\]]*[^\d\]])[^\]]*\]|\([^)]*\)/g;
  const seasonPrefixRegex = /\b(?:Season|S)\s*\d{1,2}\s*-\s*/gi;

  function matchesEpisode(query, filename) {
    filename = filename
      .replace(releaseMetadataRegex, '')
      .replace(seasonPrefixRegex, '');
    const episodeNumber = new RegExp(
      `(?:[sS]\\d{1,2}[eE]|(?:^|[^A-Za-z0-9]))0*${parseInt(query, 10)}(?!\\d)`,
    );
    return episodeNumber.test(filename);
  }


  test('matches non-padded numeric queries', () => {
    const cases = [
      ['7', '[NanakoRaws] Tsue to Tsurugi no Wistoria S2 - 07 (AT-X 1080p HEVC AAC).ass'],
      ['13', '[Nekomoe kissaten&LoliHouse] Tsue to Tsurugi no Wistoria - 13 [WebRip 1080p HEVC-10bit AAC ASSx2][CHS, JPN].ass'],
      ['18', '杖と剣のウィストリア.S02E18.第十八話.第一開祭.WEBRip.Netflix.ja[cc].srt'],
      ['8', '[Studio GreenTea] Omagoto [08][WebRip][HEVC-10bit 1080p AAC ASSx2][CHS, JPN].ass'],
    ];

    for (const [query, filename] of cases) {
      assert.equal(matchesEpisode(query, filename), true, `${query} should match ${filename}`);
    }
  });

  test('matches padded numeric queries', () => {
    const cases = [
      ['07', '[NanakoRaws] Tsue to Tsurugi no Wistoria S2 - 07 (AT-X 1080p HEVC AAC).ass'],
      ['007', '[NanakoRaws] Tsue to Tsurugi no Wistoria S2 - 07 (AT-X 1080p HEVC AAC).ass'],
      ['07', '[shincaps] Tsue to Tsurugi no Wistoria Season 2 - 07 (AT-X 1440x1080 MPEG2 AAC).srt'],
      ['007', '[shincaps] Tsue to Tsurugi no Wistoria Season 2 - 07 (AT-X 1440x1080 MPEG2 AAC).srt'],
      ['08', '[Studio GreenTea] Omagoto [08][WebRip][HEVC-10bit 1080p AAC ASSx2][CHS, JPN].ass'],
      ['008', '[Studio GreenTea] Omagoto [08][WebRip][HEVC-10bit 1080p AAC ASSx2][CHS, JPN].ass'],
    ];

    for (const [query, filename] of cases) {
      assert.equal(matchesEpisode(query, filename), true, `${query} should match ${filename}`);
    }
  });

  test('matches SxxExx episode notation', () => {
    const cases = [
      ['13', '杖と剣のウィストリア.S02E13.第十三話.境界の日.WEBRip.Netflix.ja[cc].srt'],
      ['18', '杖と剣のウィストリア.S02E18.第十八話.第一開祭.WEBRip.Netflix.ja[cc].srt'],
      ['26', '新世紀エヴァンゲリオン.S01E26.最終話.世界の中心でアイを叫んだけもの.WEBRip.Netflix.ja[cc].srt'],
    ];

    for (const [query, filename] of cases) {
      assert.equal(matchesEpisode(query, filename), true, `${query} should match ${filename}`);
    }
  });

  test('keeps numeric bracketed episode markers', () => {
    const cases = [
      ['8', '[Studio GreenTea] Omagoto [08][WebRip][HEVC-10bit 1080p AAC ASSx2][CHS, JPN].ass'],
      ['08', '[Studio GreenTea] Omagoto [08][WebRip][HEVC-10bit 1080p AAC ASSx2][CHS, JPN].ass'],
    ];

    for (const [query, filename] of cases) {
      assert.equal(matchesEpisode(query, filename), true, `${query} should match ${filename}`);
    }
  });

  test('does not match release metadata', () => {
    const cases = [
      ['8', '[Nekomoe kissaten&LoliHouse] Tsue to Tsurugi no Wistoria - 13 [WebRip 1080p HEVC-10bit AAC ASSx2][CHS, JPN].ass'],
      ['1080', '[Nekomoe kissaten&LoliHouse] Tsue to Tsurugi no Wistoria - 13 [WebRip 1080p HEVC-10bit AAC ASSx2][CHS, JPN].ass'],
      ['10', '[Studio GreenTea] Omagoto [08][WebRip][HEVC-10bit 1080p AAC ASSx2][CHS, JPN].ass'],
    ];

    for (const [query, filename] of cases) {
      assert.equal(matchesEpisode(query, filename), false, `${query} should not match ${filename}`);
    }
  });

  test('does not match season numbers', () => {
    const cases = [
      ['2', '[NanakoRaws] Tsue to Tsurugi no Wistoria S2 - 07 (AT-X 1080p HEVC AAC).ass'],
      ['02', '[NanakoRaws] Tsue to Tsurugi no Wistoria S2 - 07 (AT-X 1080p HEVC AAC).ass'],
      ['2', '[shincaps] Tsue to Tsurugi no Wistoria Season 2 - 07 (AT-X 1440x1080 MPEG2 AAC).srt'],
      ['02', '[shincaps] Tsue to Tsurugi no Wistoria Season 2 - 07 (AT-X 1440x1080 MPEG2 AAC).srt'],
      ['2', '杖と剣のウィストリア.S02E13.第十三話.境界の日.WEBRip.Netflix.ja[cc].srt'],
      ['02', '杖と剣のウィストリア.S02E13.第十三話.境界の日.WEBRip.Netflix.ja[cc].srt'],
    ];

    for (const [query, filename] of cases) {
      assert.equal(matchesEpisode(query, filename), false, `${query} should not match ${filename}`);
    }
  });
  ```
