### PR TITLE
Sort entry files by name for a stable default order

### DIFF
--- a/src/routes/entry.rs
+++ b/src/routes/entry.rs
@@ -86,6 +86,8 @@ pub(crate) fn get_file_entries(entry_id: i64, path: &std::path::Path) -> std::io
             last_modified,
         });
     }
+    // read_dir order is arbitrary; sort by name for a stable default.
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(entries)
 }
 

--- a/src/routes/entry.rs
+++ b/src/routes/entry.rs
@@ -87,7 +87,7 @@ pub(crate) fn get_file_entries(entry_id: i64, path: &std::path::Path) -> std::io
         });
     }
     // read_dir order is arbitrary; sort by name for a stable default.
-    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    entries.sort_by_key(|e| e.name.as_str());
     Ok(entries)
 }
 


### PR DESCRIPTION
## Why

As a consumer of the files API (asbplayer — which we've talked about before),
the current response order is hard to work with: `get_file_entries` returns
files in raw `read_dir` order, and the API exposes no sort option. A name sort
gives two things for free that matter for subtitle picking — a natural
episode order, and grouping by source/release — instead of an arbitrary
scramble. The web UI already hides this by sorting client-side, but API
consumers can't.

## Change

Sort by name at the end of `get_file_entries`, so every caller (web UI, REST
API, batch endpoint) gets a stable ascending name order.

I went straight to a PR instead of an issue since the change is one line. If
there's a reason it was left unsorted, or you'd rather keep sorting on the
consumer side, feel free to close this and we can discuss.
